### PR TITLE
Use constructor injection for twitter service

### DIFF
--- a/src/OhTenPHP/Website/SiteBundle/Resources/config/services.xml
+++ b/src/OhTenPHP/Website/SiteBundle/Resources/config/services.xml
@@ -10,9 +10,7 @@
 
         <service class="OhTenPHP\Website\SiteBundle\Services\TwitterService"
                  id="oh_ten_php_website_site.services.twitter_service">
-            <call method="setTwitterClient">
-                <argument id="endroid.twitter" type="service"/>
-            </call>
+            <argument id="endroid.twitter" type="service"/>
         </service>
 
         <service class="OhTenPHP\Website\SiteBundle\Services\MeetupService"

--- a/src/OhTenPHP/Website/SiteBundle/Services/TwitterService.php
+++ b/src/OhTenPHP/Website/SiteBundle/Services/TwitterService.php
@@ -1,51 +1,40 @@
 <?php
+
 namespace OhTenPHP\Website\SiteBundle\Services;
 
-/**
- * Class TwitterService
- * @package OhTenPHP\Website\SiteBundle\Services
- */
+use Endroid\Twitter\Twitter;
+
 class TwitterService
 {
     /**
-     * Holds the default amount to retrieve from the twitter timeline.
+     * Holds the amount to retrieve from the twitter timeline.
      */
-    const DEFAULT_TIMELINE_COUNT = 5;
+    const TIMELINE_COUNT = 5;
 
     /**
-     * Holds the twitter client object
-     * @var
+     * Holds the twitter client object.
+     *
+     * @var Twitter
      */
-    protected $twitterClient;
+    private $client;
 
     /**
-     * Returns the latest tweets from the defined user timeline
-     * @param int $count
+     * @param Twitter $client
+     */
+    public function __construct(Twitter $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Returns the latest tweets from the defined user timeline.
+     *
      * @return mixed
      */
-    public function getLatestTweets($count = self::DEFAULT_TIMELINE_COUNT)
+    public function getLatestTweets()
     {
-        $twitter = $this->getTwitterClient();
-        return $twitter->getTimeline([
-            'count' => $count,
+        return $this->client->getTimeline([
+            'count' => self::TIMELINE_COUNT,
         ]);
-    }
-
-    /**
-     * Returns the twitter client object
-     * @return mixed
-     */
-    public function getTwitterClient()
-    {
-        return $this->twitterClient;
-    }
-
-    /**
-     * Sets the twitter client object
-     * @param mixed $twitterClient
-     */
-    public function setTwitterClient($twitterClient)
-    {
-        $this->twitterClient = $twitterClient;
     }
 }

--- a/src/OhTenPHP/Website/SiteBundle/Tests/Services/TwitterServiceTest.php
+++ b/src/OhTenPHP/Website/SiteBundle/Tests/Services/TwitterServiceTest.php
@@ -12,9 +12,6 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 class TwitterServiceTest extends KernelTestCase
 {
     protected $twitterService;
-    protected $insert = [
-        'foo' => 'bar'
-    ];
 
     protected function setUp()
     {
@@ -27,20 +24,19 @@ class TwitterServiceTest extends KernelTestCase
         $this->assertInstanceOf(TwitterService::class, $this->twitterService);
     }
 
-    public function testSetTwitterClient()
-    {
-        $this->twitterService->setTwitterClient($this->insert);
-        $this->assertEquals($this->insert, $this->twitterService->getTwitterClient());
-    }
-
     public function testGetLatestTweets()
     {
-        $mockeryMock = \Mockery::mock('AnInexistentClass');
+        $expected = [
+            ['text' => 'hello world'],
+        ];
+
+        $mockeryMock = \Mockery::mock(Twitter::class);
         $mockeryMock
             ->shouldReceive('getTimeline')->once()
-            ->andReturn($this->insert);
-        $this->twitterService->setTwitterClient($mockeryMock);
-        $this->assertEquals($this->insert, $this->twitterService->getLatestTweets());
+            ->andReturn($expected);
+
+        $service = new TwitterService($mockeryMock);
+        $this->assertEquals($expected, $service->getLatestTweets());
     }
 
 


### PR DESCRIPTION
I don't think we need a KernelTestCase for the twitter service anymore. Feels like we should do this elsewhere.

This stronly reflects my opinion on writing software, the code that already existed was fine, so feel free to destroy this code.

### Why?

Because set/getTwitterClient is removed from the class. A developer using the service will not be tempted to use the underlying client, because he has no access to it. Instead he will create a nice function in the service that reflects the use case (s)he will need.

### Why?

Well if the user would use the underlying TwitterClient (in this case a pretty nice one :)) we are binding our bussiness/domain logic to the framework.

### Why?

Well by binding your domain to a specific framework/lib you will lose the ability to update to newer/beter/feature-richer lib.

### So why remove the `$count` parameter

We do not have any usecases that would require us to fetch more. However some feature creaping boss (@caroga for example :P) Might force a feature/use-case upon us that requires a different parameter. In that case we made a wrong assumption that this would be future proof and we are required to break backwards compatibility without ever using the functionaltity.

### Implement a freaking cache already

Uuuhm I guess you're right.