### PR TITLE
Add venue details; Fix venue issue in template

### DIFF
--- a/app/Resources/views/layout/meetup-countdown.html.twig
+++ b/app/Resources/views/layout/meetup-countdown.html.twig
@@ -2,6 +2,9 @@
     <div class="row">
         <div class="col-lg-12 center">
             <h2>{{ meetup.name }}</h2>
+            {% if meetup.venue is defined %}
+                <p>{{ meetup.venue.name }}, {{ meetup.venue.address_1 }} {{ meetup.venue.city }}</p>
+            {% endif %}
             <hr>
             <h3 id="finalCountdownTimer"></h3>
             <span id="finalCountdownTimerTimeytime" class="hidden">{{ meetup.time }}</span>
@@ -12,6 +15,7 @@
         </div>
     </div>
 </div>
+{% if meetup.venue is defined %}
 <div class="row">
     <div class="col-lg-12">
         <iframe frameborder="0" scrolling="no" marginheight="0" marginwidth="0" width="100%" height="200"
@@ -19,6 +23,7 @@
         </iframe>
     </div>
 </div>
+{% endif %}
 <div class="row">
     <div class="col-lg-12 js-packery" id="masonryContainer"
          data-packery-options='{ "itemSelector": ".masonryItem", "gutter": 0 }'>


### PR DESCRIPTION
Only shows the Google Maps iframe if a venue is set. Also adds venue address details to the meetup layout. For a complete meetup (with venue) it will then look something like this:

<img width="809" alt="screen shot 2016-07-19 at 22 15 35" src="https://cloud.githubusercontent.com/assets/567664/16964998/62166016-4dfe-11e6-9ce3-698400c7dd50.png">
